### PR TITLE
Allow update setting if find user.id equals req user.id

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -97,8 +97,8 @@ const userController = {
     ])
       .then(([checkUsers, user, hash]) => {
         if (!user) throw new Error('帳號不存在！')
-        if (checkUsers.some(u => u.email === email)) throw new Error('email 已重複註冊！')
-        if (checkUsers.some(u => u.account === account)) throw new Error('account 已重複註冊！')
+        if (checkUsers.some(u => u.email === email && u.id !== helpers.getUser(req).id)) throw new Error('email 已重複註冊！')
+        if (checkUsers.some(u => u.account === account && u.id !== helpers.getUser(req).id)) throw new Error('account 已重複註冊！')
         return user.update({
           account,
           name,


### PR DESCRIPTION
當 user update setting 時，因為 name, account and email 都是必須的，所以使用者仍要填寫 account & email
但若使用者只想更改 name or password，在 account & email 填上原來，提交後，就會回傳錯誤
現加上 若資料庫 用 account or email 找回來的 user，其 user.id !== req user.id 時，才回傳錯誤